### PR TITLE
fix: switch cluster engine from Kind to k3d

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,11 +25,11 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		30100
+		80
 	],
 	// add labels
 	"portsAttributes": {
-		"30100": { "label": "Application Web UI" }
+		"80": { "label": "Application Web UI" }
 	},
 
 	"hostRequirements": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,7 +4,7 @@ source .devcontainer/util/source_framework.sh
 
 setUpTerminal
 
-startKindCluster
+startK3dCluster
 
 installK9s
 

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-v1.3.1}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-v1.3.2}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-v1.3.2}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.2}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.2}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.4}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"


### PR DESCRIPTION
## Summary
- Replace `startKindCluster` with `startK3dCluster` in `.devcontainer/post-create.sh`

## Why
Kind requires 4-level container nesting (Kind → Docker → Sysbox → EC2). Sysbox only supports 3 levels. Result: all pods stuck in `ContainerCreating` indefinitely on every nightly run.

K3d works at 3 levels and has been the framework default since v1.3.0.

## Test plan
- [ ] Nightly CI run passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)