### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/getting-started.js"
 --8<-- "snippets/grail-requirements.md"
 
 ## Prerequisites

--- a/docs/3-codespaces.md
+++ b/docs/3-codespaces.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/3-codespaces.js"
 
 ## Create Codespace
 

--- a/docs/4-dynatrace-buckets.md
+++ b/docs/4-dynatrace-buckets.md
@@ -1,5 +1,4 @@
 # Dynatrace Buckets (Storage Management)
---8<-- "snippets/send-bizevent/6-dynatrace-buckets.js"
 
 In this module we'll create Grail storage Buckets to manage log data.  By default, all logs are stored in a default logs bucket in Grail - that retains log data for 35 days.  We can create custom buckets with different retention periods to solve for our log management and analytics use cases.
 

--- a/docs/5-dynatrace-openpipeline-astronomy-shop-logs.md
+++ b/docs/5-dynatrace-openpipeline-astronomy-shop-logs.md
@@ -1,5 +1,4 @@
 # Dynatrace OpenPipeline - Astronomy Shop Logs
---8<-- "snippets/send-bizevent/7-dynatrace-openpipeline-astronomy-shop-logs.js"
 
 In this module we'll utilize Dynatrace OpenPipeline to process `astronomy-shop` application logs at ingest, in order to make them easier to analyze and leverage.  The logs will be ingested by OpenTelemetry Collector, deployed on Kubernetes as part of the previous module.  With OpenPipeline, the logs will be processed at ingest, to manipulate fields, extract metrics, and raise alert events in case of any issues.
 

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/cleanup.js"
 
 !!! tip "Deleting the codespace from inside the container"
     We like to make your life easier, for convenience there is a function loaded in the shell of the Codespace for deleting the codespace, just type `deleteCodespace`. This will trigger the deletion of the codespace.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/index.js"
 
 --8<-- "snippets/disclaimer.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/snippets/send-bizevent/2-getting-started.js
+++ b/docs/snippets/send-bizevent/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/3-codespaces.js
+++ b/docs/snippets/send-bizevent/3-codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"})
-});
-</script>

--- a/docs/snippets/send-bizevent/4-opentelemetry-logs.js
+++ b/docs/snippets/send-bizevent/4-opentelemetry-logs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. OpenTelemetry Logs"})
-});
-</script>

--- a/docs/snippets/send-bizevent/5-opentelemetry-capstone.js
+++ b/docs/snippets/send-bizevent/5-opentelemetry-capstone.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. OpenTelemetry Capstone"})
-});
-</script>

--- a/docs/snippets/send-bizevent/6-dynatrace-buckets.js
+++ b/docs/snippets/send-bizevent/6-dynatrace-buckets.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Dynatrace Buckets"})
-});
-</script>

--- a/docs/snippets/send-bizevent/7-dynatrace-openpipeline-astronomy-shop-logs.js
+++ b/docs/snippets/send-bizevent/7-dynatrace-openpipeline-astronomy-shop-logs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. Dynatrace OpenPipeline Astronomy Shop Logs"})
-});
-</script>

--- a/docs/snippets/send-bizevent/8-dynatrace-openpipeline-kubernetes-events.js
+++ b/docs/snippets/send-bizevent/8-dynatrace-openpipeline-kubernetes-events.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "8. Dynatrace OpenPipeline Kubernetes Events"})
-});
-</script>

--- a/docs/snippets/send-bizevent/9-dynatrace-openpipeline-collector-logs.js
+++ b/docs/snippets/send-bizevent/9-dynatrace-openpipeline-collector-logs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "9. Dynatrace OpenPipeline Collector Logs"})
-});
-</script>

--- a/docs/snippets/send-bizevent/cleanup.js
+++ b/docs/snippets/send-bizevent/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "Cleanup"})
-});
-</script>

--- a/docs/snippets/send-bizevent/index.js
+++ b/docs/snippets/send-bizevent/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "About"})
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)